### PR TITLE
Update biopython to version 1.85

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "biopython == 1.84",    # pinned because biopython does not comply with semantic versioning
+    "biopython == 1.85",   # pinned because biopython does not comply with semantic versioning
     "blosum ~= 2.0",
     "click ~=8.1",
     "psutil ~=5.9",


### PR DESCRIPTION
This PR updates the biopython dependency from version 1.84 to 1.85.

The change keeps the same pinning approach since biopython does not comply with semantic versioning, just updating to the newer version.