### PR TITLE
feat(api): add scheme mapping utils and tests

### DIFF
--- a/riot_na/api/utils.py
+++ b/riot_na/api/utils.py
@@ -1,9 +1,23 @@
 from functools import cache
 
+from riot_na import ChainType, Locus, Scheme
 from riot_na.data.model import AirrRearrangementEntryAA, ShortRegion
+from riot_na.data.scheme_regions import get_region
 
 
 def get_region_position_indices(airr: AirrRearrangementEntryAA, region: ShortRegion) -> list[int]:
+    """
+    Return zero-based amino acid indices for a single region in an AIRR entry.
+
+    Parameters:
+    -----------
+    - airr : AIRR rearrangement entry with region boundary coordinates.
+    - region : CDR or framework region to resolve.
+
+    Returns:
+    -----------
+    List of zero-based indices covering the requested region.
+    """
     match region:
         case ShortRegion.CDR1:
             assert airr.cdr1_start_aa and airr.cdr1_end_aa
@@ -29,6 +43,18 @@ def get_region_position_indices(airr: AirrRearrangementEntryAA, region: ShortReg
 
 
 def get_regions_position_indices(airr: AirrRearrangementEntryAA, regions: list[ShortRegion]) -> list[int]:
+    """
+    Return zero-based amino acid indices for multiple regions in an AIRR entry.
+
+    Parameters:
+    -----------
+    - airr : AIRR rearrangement entry with region boundary coordinates.
+    - regions : CDR and/or framework regions to resolve.
+
+    Returns:
+    -----------
+    Sorted list of unique zero-based indices across all requested regions.
+    """
     indices = set()
     for region in regions:
         indices.update(get_region_position_indices(airr, region))
@@ -36,12 +62,35 @@ def get_regions_position_indices(airr: AirrRearrangementEntryAA, regions: list[S
 
 
 def scheme_positions_to_index(airr: AirrRearrangementEntryAA, scheme_positions: list[str]) -> list[int]:
+    """
+    Map scheme position labels to zero-based sequence indices.
+
+    Parameters:
+    -----------
+    - airr : AIRR rearrangement entry with positional_scheme_mapping populated.
+    - scheme_positions : Scheme position labels to look up (e.g. "111A").
+
+    Returns:
+    -----------
+    Zero-based indices corresponding to the given scheme positions.
+    """
     assert airr.positional_scheme_mapping
     scheme_positional_mapping = {v: k for k, v in airr.positional_scheme_mapping.items()}
     return [scheme_positional_mapping[pos] for pos in scheme_positions]
 
 
 def get_primary_seq(airr: AirrRearrangementEntryAA) -> str:
+    """
+    Reconstruct the numbered amino acid sequence from scheme residue mapping.
+
+    Parameters:
+    -----------
+    - airr : AIRR rearrangement entry with scheme_residue_mapping populated.
+
+    Returns:
+    -----------
+    Amino acid sequence formed by joining mapped residues in scheme order.
+    """
     assert airr.scheme_residue_mapping is not None
     return "".join(airr.scheme_residue_mapping.values())
 
@@ -65,8 +114,88 @@ def int_to_str_insertion(n: int) -> str:
 
 
 def map_insertion_number_to_letter(position: str) -> str:
-    # Translates 111.1, 111.2 to 111A, 111B ETC
+    """
+    Convert numeric insertion notation to IMGT-style position labels.
+
+    Parameters:
+    -----------
+    - position : Scheme position, optionally with a numeric insertion suffix
+      (e.g. "111.1", "111.2").
+
+    Returns:
+    -----------
+    Position label with insertion letters (e.g. "111A", "111B"), or the
+    original value when no insertion suffix is present.
+    """
     if "." not in position:
         return position
     position_number, insertion_number = position.split(".")
     return f"{position_number}{int_to_str_insertion(int(insertion_number))}"
+
+
+def str_to_int_insertion(position: str) -> int:
+    """
+    Extract the integer scheme position from a position label.
+
+    Parameters:
+    -----------
+    - position : Scheme position label, with or without an insertion suffix
+      (e.g. "111", "111.1", "112.1", "112.2", etc.).
+
+    Returns:
+    -----------
+    Integer scheme position, ignoring any insertion suffix.
+    """
+    return int(position.split(".", maxsplit=1)[0])
+
+
+def get_scheme_residue_mapping_insertions_as_letters(
+    airr: AirrRearrangementEntryAA,
+) -> dict[str, str]:
+    """
+    Convert scheme residue mapping insertions to IMGT-style position labels (e.g. "111.1" -> "111A", "111.2" -> "111B", etc.).
+
+    Parameters:
+    -----------
+    - airr : AIRR rearrangement entry with scheme_residue_mapping populated.
+
+    Returns:
+    -----------
+    Scheme residue mapping with insertions converted to letters (e.g. {"111A": "G", "111B": "K"}).
+    """
+    assert airr.scheme_residue_mapping is not None
+    return {
+        map_insertion_number_to_letter(scheme_position): residue
+        for scheme_position, residue in airr.scheme_residue_mapping.items()
+    }
+
+
+def get_scheme_residue_mapping_by_region(
+    airr: AirrRearrangementEntryAA,
+) -> dict[ShortRegion, dict[str, str]]:
+    """
+    Group scheme residue mapping entries by CDR/framework region.
+
+    Parameters:
+    -----------
+    - airr : AIRR rearrangement entry with scheme_residue_mapping, locus,
+      and numbering_scheme populated.
+
+    Returns:
+    -----------
+    Mapping from each ShortRegion to its scheme-position-to-residue entries.
+    """
+    assert airr.scheme_residue_mapping is not None
+    assert airr.locus is not None
+    assert airr.numbering_scheme is not None
+
+    chain_type = ChainType.from_locus(Locus(airr.locus))
+    region_scheme_residue_mapping: dict[ShortRegion, dict[str, str]] = {}
+    for scheme_position, residue in airr.scheme_residue_mapping.items():
+        region = get_region(
+            str_to_int_insertion(scheme_position),
+            Scheme(airr.numbering_scheme),
+            chain_type,
+        )
+        region_scheme_residue_mapping.setdefault(region, {})[scheme_position] = residue
+    return region_scheme_residue_mapping

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,59 @@
-from riot_na.api.utils import map_insertion_number_to_letter
+import pytest
+
+from riot_na import Scheme, get_or_create_riot_aa
+from riot_na.api.utils import (
+    get_primary_seq,
+    get_region_position_indices,
+    get_regions_position_indices,
+    get_scheme_residue_mapping_by_region,
+    get_scheme_residue_mapping_insertions_as_letters,
+    int_to_str_insertion,
+    map_insertion_number_to_letter,
+    scheme_positions_to_index,
+    str_to_int_insertion,
+)
+from riot_na.data.model import AirrRearrangementEntryAA, ShortRegion
+
+HEAVY_CHAIN_WITH_INSERTIONS = "EVQLVESGGGLVQPGGSLRLSCAASGFTFSSYNMNWVRQAPGKGLEWVSYISSSSSTIYYADSVKGRFTISRDNAKNSLSLQMNSLRDEDTAVYYCARAYYQPGKPGKQQYGMDVWGQGTTVTVSS"
+
+
+@pytest.fixture(scope="module", name="airr_heavy")
+def heavy_chain_airr() -> AirrRearrangementEntryAA:
+    return get_or_create_riot_aa().run_on_sequence("", HEAVY_CHAIN_WITH_INSERTIONS, scheme=Scheme.IMGT)
+
+
+@pytest.mark.parametrize(
+    ("n", "expected"),
+    [
+        (1, "A"),
+        (2, "B"),
+        (26, "Z"),
+        (27, "AA"),
+        (28, "AB"),
+        (52, "AZ"),
+        (53, "BA"),
+        (100, "CV"),
+    ],
+)
+def test_int_to_str_insertion(n, expected):
+    assert int_to_str_insertion(n) == expected
+
+
+def test_int_to_str_insertion_rejects_non_positive():
+    with pytest.raises(ValueError, match="positive integer"):
+        int_to_str_insertion(0)
+
+
+@pytest.mark.parametrize(
+    ("position", "expected"),
+    [
+        ("111", 111),
+        ("111.1", 111),
+        ("112.2", 112),
+    ],
+)
+def test_str_to_int_insertion(position, expected):
+    assert str_to_int_insertion(position) == expected
 
 
 def test_map_insertion_number_to_letter_no_decimal():
@@ -54,3 +109,62 @@ def test_map_insertion_number_to_letter_large_insertion():
 
     # then
     assert result == "111CV"
+
+
+def test_get_region_position_indices(airr_heavy):
+    assert get_region_position_indices(airr_heavy, ShortRegion.CDR1) == list(range(25, 33))
+    assert get_region_position_indices(airr_heavy, ShortRegion.CDR3) == list(range(96, 115))
+
+
+def test_get_regions_position_indices(airr_heavy):
+    result = get_regions_position_indices(airr_heavy, [ShortRegion.CDR1, ShortRegion.CDR3])
+
+    assert result == sorted(set(range(25, 33)) | set(range(96, 115)))
+
+
+def test_scheme_positions_to_index(airr_heavy):
+    assert scheme_positions_to_index(airr_heavy, ["27", "111.1", "111.2"]) == [25, 103, 104]
+
+
+def test_get_primary_seq(airr_heavy):
+    assert get_primary_seq(airr_heavy) == HEAVY_CHAIN_WITH_INSERTIONS
+
+
+def test_get_scheme_residue_mapping_insertions_as_letters(airr_heavy):
+    result = get_scheme_residue_mapping_insertions_as_letters(airr_heavy)
+
+    assert result["111"] == "P"
+    assert result["111A"] == "G"
+    assert result["111B"] == "K"
+    assert result["111C"] == "P"
+    assert result["112A"] == "Q"
+    assert result["112B"] == "K"
+    assert result["112C"] == "G"
+    assert result["112"] == "Q"
+
+
+def test_get_scheme_residue_mapping_by_region(airr_heavy):
+    result = get_scheme_residue_mapping_by_region(airr_heavy)
+
+    assert len(result[ShortRegion.FW1]) == 25
+    assert result[ShortRegion.CDR3] == {
+        "105": "A",
+        "106": "R",
+        "107": "A",
+        "108": "Y",
+        "109": "Y",
+        "110": "Q",
+        "111": "P",
+        "111.1": "G",
+        "111.2": "K",
+        "111.3": "P",
+        "112.3": "G",
+        "112.2": "K",
+        "112.1": "Q",
+        "112": "Q",
+        "113": "Y",
+        "114": "G",
+        "115": "M",
+        "116": "D",
+        "117": "V",
+    }


### PR DESCRIPTION
Add helpers to group scheme residues by region and convert
insertion positions to IMGT letter notation. Document existing
api/utils functions and cover them with integration tests.
